### PR TITLE
Removed argument from `json_encode` and made `getMessages()` public 

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -49,7 +49,7 @@ class Exception extends PHPException implements ExceptionInterface
 
         $messages[] = $message;
         /** @noinspection JsonEncodingApiUsageInspection */
-        $this->message = json_encode($messages, true);
+        $this->message = json_encode($messages);
 
         return $this;
     }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -33,7 +33,7 @@ class Exception extends PHPException implements ExceptionInterface
         return $this;
     }
 
-    private function getMessages(): array
+    public function getMessages(): array
     {
         return $this->messages;
     }


### PR DESCRIPTION
Removed argument from `json_encode` and made `getMessages()` public in Exception.php. This is for integration with legacy UserManager running PHP 7.2 for the Sign in with Apple project.