### PR TITLE
Exposing getMessages in ExceptionInterface.

### DIFF
--- a/src/ExceptionInterface.php
+++ b/src/ExceptionInterface.php
@@ -15,4 +15,6 @@ interface ExceptionInterface extends Throwable, JsonSerializable
     public function jsonSerialize();
 
     public function addMessage(string $message): ExceptionInterface;
+
+    public function getMessages(): array;
 }


### PR DESCRIPTION
What's the deal with addMessage() if there's no getMessages() method in the interface?
I use the NonTransientException for 404 HTTP requests. The constructor doesn't take a message, so I have to use addMessage(). addMessage() makes it possible to specify the message after the constructor is run.
I need a way to get the added message. Without the method in the interface I'm forced to use the class instead of the interface.
https://github.com/neighborhoods/InquiryService/blob/master/src/AddBuyerInquiryHttpApi/BuyerInquiry/Repository/Handler.php#L42